### PR TITLE
fix: support non-latin characters in search keyword

### DIFF
--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,10 +1,37 @@
 /**
+ * Transform a string into a search keyword that can be used in search.
+ *
+ * @example
  * "luna test 1" => "luna+test+1"
  * "  luna    +test+1 " => "luna+test+1"
+ * "（香港］ +学 生" => "香港+学+生"
  */
 export function searchify(keyword: string) {
     return keyword
-        .replace(/[^a-zA-Z0-9\s]/g, ' ')
+        .replace(/^[ \t]+|[ \t]+$/gi, '')
+        .replace(/[\.,'/:=\(\)&!\?@\[\]"\*\$#%\^;\|`\\~><¿\{\}\+]/gi, ' ')
+        .replace(/[éèëê]/gi, 'e')
+        .replace(/[äàâ]/gi, 'a')
+        .replace(/[üùû]/gi, 'u')
+        .replace(/[îï]/gi, 'i')
+        .replace(/ô/gi, 'o')
+        .replace(/ç/gi, 'c')
+        .replace(/【/gi, '')
+        .replace(/】/gi, '')
+        .replace(/〈/gi, '')
+        .replace(/〉/gi, '')
+        .replace(/〖/gi, '')
+        .replace(/〗/gi, '')
+        .replace(/（/gi, '')
+        .replace(/）/gi, '')
+        // eslint-disable-next-line no-irregular-whitespace
+        .replace(/　/gi, '')
+        .replace(/〔/gi, '')
+        .replace(/〕/gi, '')
+        .replace(/『/gi, '')
+        .replace(/』/gi, '')
+        .replace(/］/gi, '')
+        .replace(/［/gi, '')
         .trim()
         .split(/\s+/)
         .join('+')


### PR DESCRIPTION
closes #98 

This PR fixes the problem that the non-latin characters will be incorrectly removed from the search string. These regexes are now aligned with the official implementation.